### PR TITLE
Sync back with XenServer packaging on %post

### DIFF
--- a/SPECS/varstored.spec
+++ b/SPECS/varstored.spec
@@ -187,7 +187,7 @@ install -m 755 %{SOURCE12} %{buildroot}/%{_sbindir}/fix-efivars.py
 %{?_cov_install}
 
 %post
-test "$(readlink %{_sharedstatedir}/%{name})" = %{_datadir}/%{name} || test -d %{_sharedstatedir}/%{name} || ln -sf -T %{_datadir}/%{name} %{_sharedstatedir}/%{name} || :
+test "$(readlink %{_sharedstatedir}/%{name})" = %{_datadir}/%{name} || test -d %{_sharedstatedir}/%{name} || ln -sf -T %{_datadir}/%{name} %{_sharedstatedir}/%{name}
 
 %check
 make check


### PR DESCRIPTION
In the past (commit 0f1106f), I had protected the first line of %post with command with `||:` in order to ensure that the next commands, specific to XCP-ng, be always executed.

Since then, our specific commands are gone, so we just differ with XenServer on this addition.

Ignoring "expected" errors can sometimes be wanted in package scriplets, but ignoring meaningful ones is more dangerous.

In this commit, I'm going back in sync with XenServer's absence of protection against a failure in that line, considering that it's important to have a warning raised by RPM in case the scriptlet fails.